### PR TITLE
Add failing Roxygen highlight tests

### DIFF
--- a/tests/highlight_roxygen.R
+++ b/tests/highlight_roxygen.R
@@ -46,21 +46,5 @@ lessbar_ = function() …
 #' markup, and is therefore just highlighted as a comment.
 x <- x
 
-#' This is a title of a Roxygen block without following newline
-#' @param foo this describes parameter foo
-#'
-#' Description
-f = function (foo) f
-
-#' Title
-#' @details Likewise, this is no longer part of the title.
-#'
-#' More description. Weird Roxygen layout, but legal.
-g = function () f
-
 #' A function with just a title, nothing else.
 small_function = function () TRUE
-
-#' Another function with a title
-#' @details The function's description. No longer title.
-another_small_function = function () FALSE

--- a/tests/highlight_roxygen.R
+++ b/tests/highlight_roxygen.R
@@ -45,3 +45,22 @@ lessbar_ = function() …
 #' This is marked as a roxygen block but does not contain any further roxygen
 #' markup, and is therefore just highlighted as a comment.
 x <- x
+
+#' This is a title of a Roxygen block without following newline
+#' @param foo this describes parameter foo
+#'
+#' Description
+f = function (foo) f
+
+#' Title
+#' @details Likewise, this is no longer part of the title.
+#'
+#' More description. Weird Roxygen layout, but legal.
+g = function () f
+
+#' A function with just a title, nothing else.
+small_function = function () TRUE
+
+#' Another function with a title
+#' @details The function's description. No longer title.
+another_small_function = function () FALSE


### PR DESCRIPTION
I’ve added some more test cases that (still) fail with the updated Roxygen highlighting.

In particular, in the first two cases (`f` and `g`) the Roxygen title termination isn’t recognised and the title format spills over on subsequent lines. In the other cases, a Roxygen block isn’t recognised as such at all.

There is no reliable way to distinguish the last two cases from your existing `x <- x` test case. However, I’d say that in all these cases the Roxygen should be highlighted as such (in fact, non-function objects can *also* be documented, so I don’t see why the `x <- x` comment shouldn’t be treated as Roxygen). I find it less important that the title part is correctly highlighted as a title, but the tags (here, `@details`) should definitely be highlighted.