### PR TITLE
Test case for Roxygen paragraph break

### DIFF
--- a/tests/highlight_roxygen.R
+++ b/tests/highlight_roxygen.R
@@ -81,3 +81,10 @@ foobar.numeric <- function(x) abs(mean(x) - median(x))
 
 #' @describeIn foobar First and last values pasted together in a string.
 foobar.character <- function(x) paste0(x[1], "-", x[length(x)])
+
+#' A description that contains a newline as a paragraph break.
+#'
+#' The above is \emph{not} a title because the Roxygen block contains an
+#' \code{@rdname} designation.
+#' @rdname arguments
+paragraph_break = function () {}


### PR DESCRIPTION
Another failing test case: Roxygen parses this as a description containing a paragraph break. There is no title because `@rdname` indicates that the title is reused from another Roxygen block.